### PR TITLE
Remove platform deploy emulation and small security improvements

### DIFF
--- a/bin/bazed.ts
+++ b/bin/bazed.ts
@@ -282,19 +282,6 @@ program
     }
   });
 
-program.command("platform").action(async (_options: object) => {
-  try {
-    await startServer({
-      port: process.env.PORT ? parseInt(process.env.PORT) : 9000,
-      openaiApiKey: process.env.OPENAI_API_KEY || "",
-      imports: [],
-      platform: true,
-    });
-  } catch (e: any) {
-    program.error(`Aborting due to an error: ${e.message}`, { exitCode: 1 });
-  }
-});
-
 const tarProject = (path: string): Promise<[string, () => void]> => {
   return new Promise((resolve, reject) => {
     const tmpDir = FS.mkdtempSync("bazed-");

--- a/src/client.ts
+++ b/src/client.ts
@@ -467,14 +467,24 @@ export const parseDuration = (duration: string): moment.Duration => {
   // moment.duration. This format is as follows:
   // 0h0m0s0ms where h, m, s, and ms sections are optional
   // for example: 6h10m0s0ms, 6m0s, 12ms, 55s, 20s200ms, etc.
+
+  if (duration.length > 64) {
+    // This is a sanity check to prevent (very unlikely) attack on regular expressions
+    console.log(
+      "WARNING: duration too long when parsing time in client:",
+      duration
+    );
+    return moment.duration(0);
+  }
+
   duration = duration.toLowerCase();
-  const parts = duration.match(/(\d+(h|ms|m|s))/g);
+  const parts = duration.match(/(\d{1,5}(h|ms|m|s))/g);
   if (parts === null) {
     console.log("WARNING: no parts when parsing time in client:", duration);
     return moment.duration(0);
   }
   const units: Record<string, number> = parts.reduce((acc, part) => {
-    const s = part.match(/(\d+)([hms]+)/);
+    const s = part.match(/(\d{1,5})(h|ms|m|s)/);
     if (s === null) {
       console.log("WARNING: invalid part format:", part);
       return acc;


### PR DESCRIPTION
Removed some unused code that aimed to emulate the platform deployment endpoint locally. This was initially used for testing but is now outdated and useless. 

The code was exposing an upload endpoint and doing some file manipulation which could become an issue if the local dev server got somehow opened to the internet. 

Improved regexp use in OpenAI client and cleaned up `tsc` invocation in development server - it now uses `execFileSync` instead of `execSync` to make sure that file paths with spaces are handled correctly.