### PR TITLE
generate full cost report in `session.report()`

### DIFF
--- a/bin/bazed.ts
+++ b/bin/bazed.ts
@@ -9,6 +9,8 @@ import { version } from "../package.json";
 import prompts from "prompts";
 import chalk from "chalk";
 import { startServer } from "../src/server/server";
+import { ModelType } from "../src/models";
+import { SessionReport } from "../src/session";
 import dotenv from "dotenv";
 import axios from "axios";
 import FormData from "form-data";
@@ -446,11 +448,7 @@ interface SpawnOptions {
 interface SpawnResponse {
   success: boolean;
   result?: string;
-  session?: {
-    cost: number;
-    elapsed: number;
-    tokens: Record<string, number>;
-  };
+  session?: SessionReport;
   error?: string;
 }
 
@@ -524,18 +522,28 @@ program
         } else {
           console.log("Session details:");
           console.log(
-            `\tCost: $${response.data.session.cost.toFixed(2)}`,
-            chalk.gray(`(${response.data.session.cost})`)
+            `\tCost: $${response.data.session.totalCost.toFixed(2)}`,
+            chalk.gray(`(${response.data.session.totalCost})`)
           );
+          console.log(`\tTokens used: ${response.data.session.totalTokens}`);
           console.log(
             `\tElapsed time: ${moment
               .duration(response.data.session.elapsed)
               .humanize()}`,
             chalk.gray(`(${response.data.session.elapsed}s)`)
           );
-          console.log("\tTokens used:");
+          console.log("\tCost per model:");
+          for (const model in response.data.session.cost) {
+            console.log(
+              `\t\t${model}: $${response.data.session.cost[model as ModelType].toFixed(2)}`,
+              chalk.gray(`(${response.data.session.cost[model as ModelType]})`)
+            );
+          }
+          console.log("\tTokens per model:");
           for (const model in response.data.session.tokens) {
-            console.log(`\t\t${model}: ${response.data.session.tokens[model]}`);
+            console.log(
+              `\t\t${model}: ${response.data.session.tokens[model as ModelType]}`
+            );
           }
         }
       }

--- a/src/agents/one-shot.ts
+++ b/src/agents/one-shot.ts
@@ -8,7 +8,7 @@ import { Thread } from "../thread";
 
 export class OneShotAgent<
   OptionsType extends AgentOptions,
-  ResultType
+  ResultType,
 > extends BaseAgent<OptionsType, void, ResultType> {
   model: ModelType = ModelType.GPT35Turbo;
   thread: Thread;

--- a/src/agents/reactive.ts
+++ b/src/agents/reactive.ts
@@ -87,7 +87,7 @@ export const otherwise = <S, This, Args extends [S, string], Return extends S>(
 export class ReactiveAgent<
   OptionsType extends AgentOptions,
   StateType,
-  ReturnType
+  ReturnType,
 > extends BaseAgent<OptionsType, StateType, ReturnType> {
   thread: Thread;
   expectsJSON: boolean = true;

--- a/src/client.ts
+++ b/src/client.ts
@@ -483,34 +483,37 @@ export const parseDuration = (duration: string): moment.Duration => {
     console.log("WARNING: no parts when parsing time in client:", duration);
     return moment.duration(0);
   }
-  const units: Record<string, number> = parts.reduce((acc, part) => {
-    const s = part.match(/(\d{1,5})(h|ms|m|s)/);
-    if (s === null) {
-      console.log("WARNING: invalid part format:", part);
+  const units: Record<string, number> = parts.reduce(
+    (acc, part) => {
+      const s = part.match(/(\d{1,5})(h|ms|m|s)/);
+      if (s === null) {
+        console.log("WARNING: invalid part format:", part);
+        return acc;
+      }
+
+      const num = parseInt(s[1], 10);
+
+      if (isNaN(num)) {
+        console.log("WARNING: NaN when parsing time in client", s[1], s[2]);
+        return acc;
+      }
+
+      const unit = {
+        s: "seconds",
+        m: "minutes",
+        h: "hours",
+        ms: "milliseconds",
+      }[s[2]];
+
+      if (!unit) {
+        console.log("WARNING: unknown unit when parsing time in client", s[2]);
+        return acc;
+      }
+
+      acc[unit] = num;
       return acc;
-    }
-
-    const num = parseInt(s[1], 10);
-
-    if (isNaN(num)) {
-      console.log("WARNING: NaN when parsing time in client", s[1], s[2]);
-      return acc;
-    }
-
-    const unit = {
-      s: "seconds",
-      m: "minutes",
-      h: "hours",
-      ms: "milliseconds",
-    }[s[2]];
-
-    if (!unit) {
-      console.log("WARNING: unknown unit when parsing time in client", s[2]);
-      return acc;
-    }
-
-    acc[unit] = num;
-    return acc;
-  }, {} as Record<string, number>);
+    },
+    {} as Record<string, number>
+  );
   return moment.duration(units);
 };

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -225,26 +225,12 @@ export const startServer = async ({
     try {
       const result = await agent.run();
       session.abort();
-      return { success: true, result, session: report(session) };
+      return { success: true, result, session: session.report() };
     } catch (e: any) {
       session.abort();
-      return { error: e.message, session: report(session) };
+      return { error: e.message, session: session.report() };
     }
   });
-
-  const report = (session: Session) => {
-    const rep = {
-      cost: session.totalCost(),
-      tokens: {} as Record<string, number>,
-      elapsed: session.metadata.timing.elapsed.asSeconds(),
-    };
-    for (const [model, cost] of Object.entries(session.report())) {
-      if (cost.total > 0) {
-        rep.tokens[model] = cost.total;
-      }
-    }
-    return rep;
-  };
 
   const listenPort = port;
 


### PR DESCRIPTION
The `session.report()` method will now generate a full cost report, including total cost and tokens used, as well as per-model summaries, and session elapsed time.