### PR TITLE
enable server logging

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -152,7 +152,7 @@ export const startServer = async ({
     )}\n   dev server ${chalk.gray("v" + version)}\n`
   );
 
-  const server = Fastify();
+  const server = Fastify({ logger: true });
 
   const apiKey = openaiApiKey;
 


### PR DESCRIPTION
Logger in fastify dev server was disabled by default, enabled it.