### PR TITLE
`yarn spawn --local` will match `PORT` used by `yarn dev`

### DIFF
--- a/bin/bazed.ts
+++ b/bin/bazed.ts
@@ -464,7 +464,8 @@ program
     try {
       let url: string;
       if (_options.local) {
-        url = "http://localhost:3000";
+        const port = process.env.PORT || 3000;
+        url = `http://localhost:${port}`;
       } else if (_options.url) {
         url = _options.url;
       } else {


### PR DESCRIPTION
The address of a dev server called by `yarn spawn --local` command will now be `http://localhost:PORT`, to match the env var `PORT` used by the `yarn dev` command.