### PR TITLE
improve errors in client and local dev server

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -12,9 +12,6 @@ const DEFAULT_MAX_RETRIES = 5;
 /** Interval for fallback clearing limit counters */
 const DEFAULT_RESET_INTERVAL = 60 * 1000;
 
-/** Generic error message to replace OpenAI API error messages with */
-const GENERIC_OPENAI_ERROR = "There was an issue communicating with OpenAI API";
-
 let ids = 0;
 
 /** Ticket is a request waiting to be fulfilled */
@@ -363,7 +360,7 @@ export class Client {
             console.log("reason:", reason);
           }
           this.inflightTickets.delete(ticket.id);
-          ticket.reject(GENERIC_OPENAI_ERROR);
+          ticket.reject(reason);
           return;
         }
 
@@ -375,7 +372,7 @@ export class Client {
               console.log("reason:", reason);
             }
             this.inflightTickets.delete(ticket.id);
-            ticket.reject(GENERIC_OPENAI_ERROR);
+            ticket.reject(reason);
             return;
           case 429:
             // rate limit or quota
@@ -387,7 +384,7 @@ export class Client {
                 console.log("reason:", reason);
               }
               this.inflightTickets.delete(ticket.id);
-              ticket.reject(GENERIC_OPENAI_ERROR);
+              ticket.reject(reason);
               return;
             }
             // retry
@@ -403,7 +400,7 @@ export class Client {
               console.log("reason:", reason);
             }
             this.inflightTickets.delete(ticket.id);
-            ticket.reject(GENERIC_OPENAI_ERROR);
+            ticket.reject(reason);
             return;
         }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -228,7 +228,13 @@ export const startServer = async ({
       return { success: true, result, session: session.report() };
     } catch (e: any) {
       session.abort();
-      return { error: e.message, session: session.report() };
+      _reply.code(500);
+      return {
+        success: false,
+        error: e.message,
+        session: session.report(),
+        trace: e.stack,
+      };
     }
   });
 


### PR DESCRIPTION
    OpenAI client will return original errors from the API.
    
    Local dev server will return errors/exceptions along with stack trace if
    available.
    
    `yarn spawn` command now has option `verbose` to show stack trace of
    errors, if available.
