### PR TITLE
Fix templates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,12 @@
     "licenser.useSPDXLicenseFormat": true,
     "licenser.customTermsAndConditions": "Copyright (C) 2023-@YEAR@ Ahyve AI Inc.",
     "licenser.disableAutoHeaderInsertion": false,
+    "javascript.inlayHints.parameterTypes.enabled": true,
+    "javascript.inlayHints.propertyDeclarationTypes.enabled": true,
+    "javascript.inlayHints.variableTypes.enabled": true,
+    "typescript.inlayHints.functionLikeReturnTypes.enabled": true,
+    "typescript.inlayHints.parameterTypes.enabled": true,
+    "files.associations": {
+        "templates/**/*.ts": "plaintext"
+    }
 }

--- a/bin/bazed.ts
+++ b/bin/bazed.ts
@@ -12,7 +12,7 @@ import { startServer } from "../src/server/server";
 import { ModelType } from "../src/models";
 import { SessionReport } from "../src/session";
 import dotenv from "dotenv";
-import axios, { AxiosResponse, AxiosError } from "axios";
+import axios, { AxiosResponse } from "axios";
 import FormData from "form-data";
 import { SingleBar } from "cli-progress";
 import tar from "tar";

--- a/templates/agents/one-shot.ts
+++ b/templates/agents/one-shot.ts
@@ -1,4 +1,4 @@
-import { AgentOptions, OneShotAgent, ModelType } from "{{BAZED_PACKAGE}}";
+import { AgentOptions, OneShotAgent, ModelType } from "BAZED_PACKAGE";
 
 export interface ExampleAgentOptions extends AgentOptions {
   /** agent options */

--- a/templates/agents/reactive.ts
+++ b/templates/agents/reactive.ts
@@ -1,9 +1,4 @@
-import {
-  AgentOptions,
-  ReactiveAgent,
-  ModelType,
-  when,
-} from "{{BAZED_PACKAGE}}";
+import { AgentOptions, ReactiveAgent, ModelType, when } from "BAZED_PACKAGE";
 import { z } from "zod";
 
 export interface ExampleAgentOptions extends AgentOptions {
@@ -26,7 +21,7 @@ export default class ExampleAgent extends ReactiveAgent<
   model: ModelType = ModelType.GPT35Turbo;
   systemPrompt: string = "... add your system prompt here ...";
 
-  async input(_options: ExampleAgent): Promise<ExampleAgentState> {
+  async input(_options: ExampleAgentOptions): Promise<ExampleAgentState> {
     /* Transform input into the initial state */
     throw new Error("Method not implemented.");
   }

--- a/templates/project/package.json
+++ b/templates/project/package.json
@@ -18,6 +18,7 @@
     "@types/node": "^20.5.0",
     "eslint": "^8.56.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "zod": "^3.22.4"
   }
 }

--- a/templates/tools/tool.ts
+++ b/templates/tools/tool.ts
@@ -1,4 +1,4 @@
-import { FunctionTool, Tool, Agent } from "{{BAZED_PACKAGE}}";
+import { FunctionTool, Tool, Agent } from "BAZED_PACKAGE";
 import { z } from "zod";
 
 /** Tool is a spicy function that can describe itself with OpenAI compatible JSON schema.*/


### PR DESCRIPTION
Tool and agent templates were using templating syntax in a wrong way resulting in broken syntax in generated files. The project template was also missing zod dependency.

I've adjusted the templates and added zod to project template package.json.
